### PR TITLE
Vagrantfile: agrupando VMs no VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure("2") do |config|
         vb.name = "#{name}"
         vb.memory = "#{conf["memory"]}"
         vb.cpus = "#{conf["cpus"]}"
+        vb.customize ["modifyvm", :id, "--groups", "/MongoDB-Lab"]
       end
       
       srv.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
Para o provider VirtualBox, dá para colocar as VMs em um grupo, que é como um diretório. Isso organiza um pouco mais as VMs para quem usa várias delas e também ajuda a lembrar no futuro para o que era as VMs e sabemos o que limpar e o que manter.